### PR TITLE
Add dark mode support for sponsor logos

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -48,31 +48,31 @@ The Foundation helps to sponsor many events, worldwide, each year. Join us at
 ### Gold Level Sponsor
 
 <div class="sponsor-logo gold">
-<a href="https://duckduckgo.com/"><img src="images/duck-duck-go.svg" alt="DuckDuckGo" title="DuckDuckGo"></a>
+<a href="https://duckduckgo.com/"><img class="nozoom" src="images/duck-duck-go.svg" alt="DuckDuckGo" title="DuckDuckGo"></a>
 </div>
 
 ### Silver Level Sponsor
 
 <div class="sponsor-logo">
-<a href="https://www.webpros.com/"><img src="images/webpros.svg" alt="WebPros" title="WebPros"></a>
+<a href="https://www.webpros.com/"><img class="nozoom" src="images/webpros.svg" alt="WebPros" title="WebPros"></a>
 </div>
 
 ### Bronze Level Sponsor
 
 <div class="sponsor-grid">
 <div class="sponsor-logo bronze">
-<a href="https://www.proxmox.com/en/"><img src="images/proxmox-full-lockup-color.svg" alt="proxmox" title="proxmox"></a>
+<a href="https://www.proxmox.com/en/"><img class="nozoom" src="images/proxmox-full-lockup-color.svg" alt="proxmox" title="proxmox"></a>
 </div>
 <div class="sponsor-logo bronze large">
-<a href="https://www.suse.com/"><img src="images/SUSE_Logo-hor_L_Green-pos_sRGB.svg" alt="SUSE" title="SUSE"></a>
+<a href="https://www.suse.com/"><img class="nozoom" src="images/SUSE_Logo-hor_L_Green-pos_sRGB.svg" alt="SUSE" title="SUSE"></a>
 </div>
 <div class="sponsor-logo bronze">
-<a href="https://www.fastmail.com/"><img src="images/FM-Logo-RGB.png" alt="fastmail" title="fastmail"></a>
+<a href="https://www.fastmail.com/"><img class="nozoom" src="images/FM-Logo-RGB.png" alt="fastmail" title="fastmail"></a>
 </div>
 <div class="sponsor-logo bronze">
-<a href="https://geizhals.at/"><img src="images/geizhals_logo_official.svg" alt="geizhals preisvergleich" title="geizhals preisvergleich"></a>
+<a href="https://geizhals.at/"><img class="nozoom" src="images/geizhals_logo_official.svg" alt="geizhals preisvergleich" title="geizhals preisvergleich"></a>
 </div>
 <div class="sponsor-logo bronze">
-<a href="https://www.e-card.bg/"><img src="images/ecard-logo.svg" alt="e-card" title="e-card"></a>
+<a href="https://www.e-card.bg/"><img class="nozoom" src="images/ecard-logo.svg" alt="e-card" title="e-card"></a>
 </div>
 </div>

--- a/content/_index.md
+++ b/content/_index.md
@@ -47,32 +47,18 @@ The Foundation helps to sponsor many events, worldwide, each year. Join us at
 
 ### Gold Level Sponsor
 
-<div class="sponsor-logo gold">
-<a href="https://duckduckgo.com/"><img class="nozoom" src="images/duck-duck-go.svg" alt="DuckDuckGo" title="DuckDuckGo"></a>
-</div>
+{{< sponsor-logo url="https://duckduckgo.com/" image="duck-duck-go.svg" alt="DuckDuckGo" class="gold" >}}
 
 ### Silver Level Sponsor
 
-<div class="sponsor-logo">
-<a href="https://www.webpros.com/"><img class="nozoom" src="images/webpros.svg" alt="WebPros" title="WebPros"></a>
-</div>
+{{< sponsor-logo url="https://www.webpros.com/" image="webpros.svg" alt="WebPros" >}}
 
 ### Bronze Level Sponsor
 
-<div class="sponsor-grid">
-<div class="sponsor-logo bronze">
-<a href="https://www.proxmox.com/en/"><img class="nozoom" src="images/proxmox-full-lockup-color.svg" alt="proxmox" title="proxmox"></a>
-</div>
-<div class="sponsor-logo bronze large">
-<a href="https://www.suse.com/"><img class="nozoom" src="images/SUSE_Logo-hor_L_Green-pos_sRGB.svg" alt="SUSE" title="SUSE"></a>
-</div>
-<div class="sponsor-logo bronze">
-<a href="https://www.fastmail.com/"><img class="nozoom" src="images/FM-Logo-RGB.png" alt="fastmail" title="fastmail"></a>
-</div>
-<div class="sponsor-logo bronze">
-<a href="https://geizhals.at/"><img class="nozoom" src="images/geizhals_logo_official.svg" alt="geizhals preisvergleich" title="geizhals preisvergleich"></a>
-</div>
-<div class="sponsor-logo bronze">
-<a href="https://www.e-card.bg/"><img class="nozoom" src="images/ecard-logo.svg" alt="e-card" title="e-card"></a>
-</div>
-</div>
+{{% sponsor-grid %}}
+{{< sponsor-logo url="https://www.proxmox.com/en/" image="proxmox-full-lockup-color.svg" alt="Proxmox" class="bronze" >}}
+{{< sponsor-logo url="https://www.suse.com/" image="SUSE_Logo-hor_L_Green-pos_sRGB.svg" alt="SUSE" class="bronze large" >}}
+{{< sponsor-logo url="https://www.fastmail.com/" image="FM-Logo-RGB.png" alt="Fastmail" class="bronze" >}}
+{{< sponsor-logo url="https://geizhals.at/" image="geizhals_logo_official.svg" alt="Geizhals Preisvergleich" class="bronze" >}}
+{{< sponsor-logo url="https://www.e-card.bg/" image="ecard-logo.svg" alt="e-card" class="bronze" >}}
+{{% /sponsor-grid %}}

--- a/content/_index.md
+++ b/content/_index.md
@@ -47,16 +47,34 @@ The Foundation helps to sponsor many events, worldwide, each year. Join us at
 
 ### Gold Level Sponsor
 
-[<img src="images/duck-duck-go.svg" alt="DuckDuckGo" title="DuckDuckGo" width="400">](https://duckduckgo.com/)
+<div class="sponsor-logo">
+<a href="https://duckduckgo.com/"><img src="images/duck-duck-go.svg" alt="DuckDuckGo" title="DuckDuckGo"></a>
+</div>
 
 ### Silver Level Sponsor
 
-[<img src="images/webpros.svg" alt="WebPros" title="WebPros" width="400">](https://www.webpros.com/)
+<div class="sponsor-logo">
+<a href="https://www.webpros.com/"><img src="images/webpros.svg" alt="WebPros" title="WebPros"></a>
+</div>
 
 ### Bronze Level Sponsor
 
-[<img src="images/proxmox-full-lockup-color.svg" alt="proxmox" title="proxmox" width="400">](https://www.proxmox.com/en/)
-[<img src="images/SUSE_Logo-hor_L_Green-pos_sRGB.svg" alt="SUSE" title="SUSE" width="400">](https://www.suse.com/)
-[<img src="images/FM-Logo-RGB.png" alt="fastmail" title="fastmail" width="400">](https://www.fastmail.com/)
-[<img src="images/geizhals_logo_official.svg" alt="geizhals preisvergleich" title="geizhals preisvergleich" width="400">](https://geizhals.at/)
-[<img src="images/ecard-logo.svg" alt="e-card" title="e-card" width="150">](https://www.e-card.bg/)
+<div class="sponsor-logo bronze">
+<a href="https://www.proxmox.com/en/"><img src="images/proxmox-full-lockup-color.svg" alt="proxmox" title="proxmox"></a>
+</div>
+
+<div class="sponsor-logo bronze">
+<a href="https://www.suse.com/"><img src="images/SUSE_Logo-hor_L_Green-pos_sRGB.svg" alt="SUSE" title="SUSE"></a>
+</div>
+
+<div class="sponsor-logo bronze">
+<a href="https://www.fastmail.com/"><img src="images/FM-Logo-RGB.png" alt="fastmail" title="fastmail"></a>
+</div>
+
+<div class="sponsor-logo bronze">
+<a href="https://geizhals.at/"><img src="images/geizhals_logo_official.svg" alt="geizhals preisvergleich" title="geizhals preisvergleich"></a>
+</div>
+
+<div class="sponsor-logo bronze">
+<a href="https://www.e-card.bg/"><img src="images/ecard-logo.svg" alt="e-card" title="e-card"></a>
+</div>

--- a/content/_index.md
+++ b/content/_index.md
@@ -47,7 +47,7 @@ The Foundation helps to sponsor many events, worldwide, each year. Join us at
 
 ### Gold Level Sponsor
 
-<div class="sponsor-logo">
+<div class="sponsor-logo gold">
 <a href="https://duckduckgo.com/"><img src="images/duck-duck-go.svg" alt="DuckDuckGo" title="DuckDuckGo"></a>
 </div>
 
@@ -63,7 +63,7 @@ The Foundation helps to sponsor many events, worldwide, each year. Join us at
 <a href="https://www.proxmox.com/en/"><img src="images/proxmox-full-lockup-color.svg" alt="proxmox" title="proxmox"></a>
 </div>
 
-<div class="sponsor-logo bronze">
+<div class="sponsor-logo bronze large">
 <a href="https://www.suse.com/"><img src="images/SUSE_Logo-hor_L_Green-pos_sRGB.svg" alt="SUSE" title="SUSE"></a>
 </div>
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -59,22 +59,20 @@ The Foundation helps to sponsor many events, worldwide, each year. Join us at
 
 ### Bronze Level Sponsor
 
+<div class="sponsor-grid">
 <div class="sponsor-logo bronze">
 <a href="https://www.proxmox.com/en/"><img src="images/proxmox-full-lockup-color.svg" alt="proxmox" title="proxmox"></a>
 </div>
-
 <div class="sponsor-logo bronze large">
 <a href="https://www.suse.com/"><img src="images/SUSE_Logo-hor_L_Green-pos_sRGB.svg" alt="SUSE" title="SUSE"></a>
 </div>
-
 <div class="sponsor-logo bronze">
 <a href="https://www.fastmail.com/"><img src="images/FM-Logo-RGB.png" alt="fastmail" title="fastmail"></a>
 </div>
-
 <div class="sponsor-logo bronze">
 <a href="https://geizhals.at/"><img src="images/geizhals_logo_official.svg" alt="geizhals preisvergleich" title="geizhals preisvergleich"></a>
 </div>
-
 <div class="sponsor-logo bronze">
 <a href="https://www.e-card.bg/"><img src="images/ecard-logo.svg" alt="e-card" title="e-card"></a>
+</div>
 </div>

--- a/content/sponsors.md
+++ b/content/sponsors.md
@@ -6,23 +6,25 @@ url: '/our-donors.html'
 ---
 ## Gold Level
 
-[<img src="images/duck-duck-go.svg" alt="DuckDuckGo" title="DuckDuckGo" width="400">](https://duckduckgo.com/)
+{{< sponsor-logo url="https://duckduckgo.com/" image="duck-duck-go.svg" alt="DuckDuckGo" class="gold" >}}
 
 ---
 
 ## Silver Level
 
-[<img src="images/webpros.svg" alt="WebPros" title="WebPros" width="400">](https://www.webpros.com/)
+{{< sponsor-logo url="https://www.webpros.com/" image="webpros.svg" alt="WebPros" >}}
 
 ---
 
 ## Bronze Level
 
-[<img src="images/proxmox-full-lockup-color.svg" alt="proxmox" title="proxmox" width="400">](https://www.proxmox.com/en/)
-[<img src="images/SUSE_Logo-hor_L_Green-pos_sRGB.svg" alt="SUSE" title="SUSE" width="400">](https://www.suse.com/)
-[<img src="images/FM-Logo-RGB.png" alt="fastmail" title="fastmail" width="400">](https://www.fastmail.com/)
-[<img src="images/geizhals_logo_official.svg" alt="geizhals preisvergleich" title="geizhals preisvergleich" width="400">](https://geizhals.at/)
-[<img src="images/ecard-logo.svg" alt="e-card" title="e-card" width="150">](https://www.e-card.bg/)
+{{% sponsor-grid %}}
+{{< sponsor-logo url="https://www.proxmox.com/en/" image="proxmox-full-lockup-color.svg" alt="Proxmox" class="bronze" >}}
+{{< sponsor-logo url="https://www.suse.com/" image="SUSE_Logo-hor_L_Green-pos_sRGB.svg" alt="SUSE" class="bronze large" >}}
+{{< sponsor-logo url="https://www.fastmail.com/" image="FM-Logo-RGB.png" alt="Fastmail" class="bronze" >}}
+{{< sponsor-logo url="https://geizhals.at/" image="geizhals_logo_official.svg" alt="Geizhals Preisvergleich" class="bronze" >}}
+{{< sponsor-logo url="https://www.e-card.bg/" image="ecard-logo.svg" alt="e-card" class="bronze" >}}
+{{% /sponsor-grid %}}
 
 ---
 

--- a/layouts/partials/extend-head.html
+++ b/layouts/partials/extend-head.html
@@ -1,0 +1,1 @@
+<link rel="stylesheet" href="/css/custom.css">

--- a/layouts/shortcodes/sponsor-grid.html
+++ b/layouts/shortcodes/sponsor-grid.html
@@ -1,0 +1,3 @@
+<div class="sponsor-grid">
+{{ .Inner }}
+</div>

--- a/layouts/shortcodes/sponsor-logo.html
+++ b/layouts/shortcodes/sponsor-logo.html
@@ -1,0 +1,3 @@
+<div class="sponsor-logo{{ with .Get "class" }} {{ . }}{{ end }}">
+<a href="{{ .Get "url" }}"><img class="nozoom" src="images/{{ .Get "image" }}" alt="{{ .Get "alt" }}" title="{{ .Get "title" | default (.Get "alt") }}"></a>
+</div>

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,6 +1,7 @@
 /* Sponsor logo styling */
 .sponsor-logo {
-  background: white;
+  background: transparent;
+  border: 1px solid #d1d5db;
   padding: 1rem;
   border-radius: 0.5rem;
   width: 420px;
@@ -8,6 +9,11 @@
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.dark .sponsor-logo {
+  background: white;
+  border: none;
 }
 
 .sponsor-logo.bronze {

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -26,3 +26,12 @@
   max-width: 100%;
   object-fit: contain;
 }
+
+/* Size modifiers for logos with different aspect ratios */
+.sponsor-logo.gold img {
+  height: 90px;
+}
+
+.sponsor-logo.large img {
+  height: 90px;
+}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -4,7 +4,8 @@
   border: 1px solid #d1d5db;
   padding: 1rem;
   border-radius: 0.5rem;
-  width: 420px;
+  width: 100%;
+  max-width: 420px;
   height: 140px;
   display: flex;
   align-items: center;
@@ -19,7 +20,7 @@
 .sponsor-grid {
   display: flex;
   flex-wrap: wrap;
-  gap: 1rem;
+  gap: 1.5rem 1rem;
 }
 
 .sponsor-logo.bronze {

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -31,6 +31,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  cursor: pointer;
 }
 
 .sponsor-logo img {
@@ -38,6 +39,7 @@
   height: 70px;
   max-width: 100%;
   object-fit: contain;
+  cursor: pointer;
 }
 
 /* Size modifiers for logos with different aspect ratios */

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,0 +1,28 @@
+/* Sponsor logo styling */
+.sponsor-logo {
+  background: white;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  width: 420px;
+  height: 140px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.sponsor-logo.bronze {
+  margin: 0.5rem;
+}
+
+.sponsor-logo a {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.sponsor-logo img {
+  width: auto;
+  height: 70px;
+  max-width: 100%;
+  object-fit: contain;
+}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -16,8 +16,14 @@
   border: none;
 }
 
+.sponsor-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
 .sponsor-logo.bronze {
-  margin: 0.5rem;
+  margin: 0;
 }
 
 .sponsor-logo a {

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -5,11 +5,12 @@
   padding: 1rem;
   border-radius: 0.5rem;
   width: 100%;
-  max-width: 420px;
-  height: 140px;
+  max-width: 320px;
+  height: 120px;
   display: flex;
   align-items: center;
   justify-content: center;
+  flex: 1 1 280px;
 }
 
 .dark .sponsor-logo {
@@ -36,7 +37,7 @@
 
 .sponsor-logo img {
   width: auto;
-  height: 70px;
+  height: 60px;
   max-width: 100%;
   object-fit: contain;
   cursor: pointer;
@@ -44,9 +45,9 @@
 
 /* Size modifiers for logos with different aspect ratios */
 .sponsor-logo.gold img {
-  height: 90px;
+  height: 75px;
 }
 
 .sponsor-logo.large img {
-  height: 90px;
+  height: 75px;
 }


### PR DESCRIPTION
## Summary
- Add white background containers for sponsor logos in dark mode for better visibility
- Add light gray outline for logos in light mode
- Create responsive grid layout for bronze sponsors
- Add reusable `sponsor-logo` and `sponsor-grid` shortcodes
- Disable image zoom/lightbox on sponsor logos so they link directly to sponsor sites
- Optimize logo sizing for consistent display across different page widths

## Test plan
- [ ] Verify sponsor logos are visible and readable in dark mode
- [ ] Verify light gray outline appears in light mode
- [ ] Check responsive layout on mobile devices
- [ ] Confirm clicking logos navigates directly to sponsor sites (no zoom)
- [ ] Test both home page and sponsors page (`/our-donors.html`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)