### PR TITLE
Fix funding.json validation error

### DIFF
--- a/static/funding.json
+++ b/static/funding.json
@@ -21,8 +21,7 @@
             "wellKnown": ""
         },
         "repositoryUrl": {
-            "url": "https://github.com/Perl/perl5",
-            "wellKnown": "https://github.com/Perl/perl5/.well-known/funding.json"
+            "url": "https://github.com/Perl/perl5"
         },
         "licenses": ["spdx:Artistic-1.0-Perl", "spdx:GPL-1.0-or-later"],
         "tags": ["programming", "perl", "interpreter", "scripting", "open-source", "core", "maintenance"]


### PR DESCRIPTION
## Summary
- Remove wellKnown field from repositoryUrl in funding.json to resolve validation error at dir.floss.fund

## Details
The validation error indicated that `projects[perl5-core-maintenance].repositoryUrl.wellKnown` should end in `/.well-known/funding-manifest-urls`. Since this file doesn't exist in the perl5 repository and the wellKnown field is optional, we've removed it entirely. The funding.json file now validates successfully.

## Test plan
- [x] Validate funding.json at dir.floss.fund
- [ ] Verify the file still serves correctly from the website

🤖 Generated with [Claude Code](https://claude.com/claude-code)