### PR TITLE
Add date tracking to sponsor logos

### DIFF
--- a/content/sponsors.md
+++ b/content/sponsors.md
@@ -19,12 +19,14 @@ The following organisations provide financial support to the Foundation at bronz
 ---
 ### Gold sponsors
 
+<!-- Logo added: 2025-10-23 (1 year display period) -->
 {{< sponsor-logo url="https://duckduckgo.com/" image="duck-duck-go.svg" alt="DuckDuckGo" class="gold" >}}
 
 ---
 
 ### Silver sponsors
 
+<!-- Logo added: 2025-10-23 (1 year display period) -->
 {{< sponsor-logo url="https://www.webpros.com/" image="webpros.svg" alt="WebPros" >}}
 
 ---
@@ -32,10 +34,15 @@ The following organisations provide financial support to the Foundation at bronz
 ### Bronze sponsors
 
 {{% sponsor-grid %}}
+<!-- Logo added: 2025-10-23 (1 year display period) -->
 {{< sponsor-logo url="https://www.proxmox.com/en/" image="proxmox-full-lockup-color.svg" alt="Proxmox" class="bronze" >}}
+<!-- Logo added: 2025-10-23 (1 year display period) -->
 {{< sponsor-logo url="https://www.suse.com/" image="SUSE_Logo-hor_L_Green-pos_sRGB.svg" alt="SUSE" class="bronze large" >}}
+<!-- Logo added: 2025-10-23 (1 year display period) -->
 {{< sponsor-logo url="https://www.fastmail.com/" image="FM-Logo-RGB.png" alt="Fastmail" class="bronze" >}}
+<!-- Logo added: 2025-10-23 (1 year display period) -->
 {{< sponsor-logo url="https://geizhals.at/" image="geizhals_logo_official.svg" alt="Geizhals Preisvergleich" class="bronze" >}}
+<!-- Logo added: 2025-10-23 (1 year display period) -->
 {{< sponsor-logo url="https://www.e-card.bg/" image="ecard-logo.svg" alt="e-card" class="bronze" >}}
 {{% /sponsor-grid %}}
 


### PR DESCRIPTION
## Summary
- Added date comments above each financial sponsor logo to track when they should be rotated out
- All current sponsors use 2025-10-23 (website go-live date) as their effective start date
- Sponsors pay for one-year logo display, so these should be reviewed around October 2026

## Implementation
Used `git log --follow -p` to determine when each logo was originally added to the repository. Since all sponsors were added before the October 23, 2025 go-live date, that date is used as the baseline for all tracking.

## Test plan
- [ ] Verify comments are present in sponsors.md
- [ ] Confirm dates are correct (2025-10-23 for all current sponsors)
- [ ] Check that HTML comments don't affect page rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)