### PR TITLE
Add merchandise landing page with both community stores

### DIFF
--- a/config/_default/menus.en.toml
+++ b/config/_default/menus.en.toml
@@ -67,10 +67,9 @@ weight = 14
 
 [[main]]
 parent = "about"
-name = "Perl Merchandise"
-url = "https://the-perl-store.creator-spring.com/"
+name = "Merchandise"
+url = "/merch.html"
 weight = 16
-target = "_blank"
 
 [[main]]
 parent = "about"

--- a/content/merchandise.md
+++ b/content/merchandise.md
@@ -1,10 +1,20 @@
 ---
 title: Perl and Raku merchandise
 url: '/merch.html'
-aliases: 
+aliases:
     - '/merch'
     - '/raku-periodic-table'
 ---
+
+Support the Perl and Raku communities by getting official merchandise from our community partners.
+
+## Official Stores
+
+### The Perl Store
+Visit [The Perl Store](https://the-perl-store.creator-spring.com/) for t-shirts, mugs, stickers, and other Perl-branded merchandise.
+
+### FreeWear - Perl and Raku
+[FreeWear](https://www.freewear.org/PerlandRaku) offers Perl and Raku merchandise with proceeds supporting the Foundation. Browse their collection of apparel and accessories.
 
 ## Posters
 
@@ -12,8 +22,9 @@ aliases:
 
 Created by [Mark Lentczner](https://www.ozonehouse.com/mark/periodic/)
 
+[![Raku Periodic Table of the Operators](/images/merch/table-small-2025.jpg)](https://www.ozonehouse.com/mark/periodic/)
 
-![Raku Periodic Table of the Operators](/images/merch/table-small-2025.jpg)
+Download or print your own copy from [Mark's site](https://www.ozonehouse.com/mark/periodic/).
 
 Reproduced with the permission of the author.
 


### PR DESCRIPTION
## Summary
- Changed Merchandise menu item to link to internal landing page instead of directly to The Perl Store
- Added FreeWear as a second official merchandise partner
- Made the Raku periodic table poster more discoverable with clickable links

## Context
FreeWear reached out requesting visibility on the website. They offer Perl and Raku merchandise with proceeds supporting the Foundation. Rather than adding another menu item or replacing the existing link, this creates a landing page that showcases both stores along with the existing Raku periodic table poster.

## Test plan
- [ ] Verify the Merchandise menu item links to `/merch.html`
- [ ] Check that both store links work correctly
- [ ] Confirm the periodic table poster image and download links function properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)