### PR TITLE
Increase visibility of TPRF Slack workspace

### DIFF
--- a/config/_default/menus.en.toml
+++ b/config/_default/menus.en.toml
@@ -61,6 +61,13 @@ weight = 12
 
 [[main]]
 parent = "about"
+name = "Join us on Slack"
+url = "https://join.slack.com/t/perlfoundation/shared_invite/zt-3ocbigsn5-Cj7aslwG5gtbj8PDrBbeOA"
+weight = 13
+target = "_blank"
+
+[[main]]
+parent = "about"
 name = "Get Involved"
 url = "/get-involved.html"
 weight = 14

--- a/content/_index.md
+++ b/content/_index.md
@@ -27,6 +27,10 @@ Check out [our prospectus](https://drive.google.com/file/d/1pQJfIW0u-4gKw1o-f18G
 
 Our [grant programs](grants.html) fund development of projects to benefit Perl, Raku and the broader Community. These grants are funded by donations and support open source developers.
 
+## Join Our Community
+
+Connect with fellow Perl and Raku developers in the [TPRF Slack workspace](https://join.slack.com/t/perlfoundation/shared_invite/zt-3ocbigsn5-Cj7aslwG5gtbj8PDrBbeOA). Get help, share your projects, and participate in discussions about the future of Perl and Raku.
+
 ## Community Happens Face-to-Face
 
 The Perl and Raku Conference is the annual North American gathering where developers share code, solve problems together, and build the relationships that keep open source thriving. In 2025, we also supported the [London Perl Workshop](https://www.londonperlworkshop.com/) and the [Perl Toolchain Summit](https://perltoolchainsummit.org/pts2025/), where maintainers collaborate on the infrastructure that powers CPAN and the tools that thousands depend on.

--- a/content/get-involved.md
+++ b/content/get-involved.md
@@ -9,10 +9,15 @@ The Perl & Raku Foundation exists to promote and support community efforts
 around the Perl and Raku programming languages. We encourage you to contribute to our ecosystem
 by:
 
-- Joining your local [Perl Mongers](http://www.pm.org/) group
+### Join the Conversation
+
+Join the [TPRF Slack workspace](https://join.slack.com/t/perlfoundation/shared_invite/zt-3ocbigsn5-Cj7aslwG5gtbj8PDrBbeOA) to connect with the community, get help, share your projects, and stay updated on what's happening in the Perl and Raku ecosystem.
+
+### Connect with the Community
+
+- Join your local [Perl Mongers](http://www.pm.org/) group
 - Visit [PerlMonks](http://perlmonks.org/)
 - Attend a [YAPC](http://www.yapc.org/) in your region of the world
-- Join the [TPRF Slack workspace](https://join.slack.com/t/perlfoundation/shared_invite/zt-3ocbigsn5-Cj7aslwG5gtbj8PDrBbeOA)
 - See how to [join the TPRF Board](/join-the-board.html)
 
 There are many other ways you can contribute to Perl and Raku including:


### PR DESCRIPTION
## Summary
- Added "Join us on Slack" link to the About menu for easy access from any page
- Created a prominent "Join Our Community" section on the homepage featuring the Slack workspace
- Highlighted the Slack workspace on the get-involved page with a dedicated "Join the Conversation" section and descriptive text

## Context
The Slack workspace link was buried in a bullet list on the get-involved page. These changes make it much more visible across the site to encourage more community participation.

## Test plan
- [ ] Verify "Join us on Slack" appears in the About dropdown menu
- [ ] Verify "Join Our Community" section appears on the homepage with working Slack link
- [ ] Verify "Join the Conversation" section is prominent on the get-involved page
- [ ] Verify Slack links open in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)