### PR TITLE
Improve footer navigation and add contact page

### DIFF
--- a/config/_default/menus.en.toml
+++ b/config/_default/menus.en.toml
@@ -262,13 +262,32 @@ weight = 8
 none = "none"
 
 [[footer]]
-name = "Contact"
-url = "mailto:hello@perlfoundation.org"
-identifier = "contact-footer"
+name = "News"
+url = "http://news.perlfoundation.org/"
+identifier = "news-footer"
 weight = 2
+target = "_blank"
+
+[[footer]]
+name = "Events"
+url = "/events.html"
+identifier = "events-footer"
+weight = 4
+
+[[footer]]
+name = "Get Involved"
+url = "/get-involved.html"
+identifier = "get-involved-footer"
+weight = 6
 
 [[footer]]
 name = "Donate"
 pageRef = "donate"
 identifier = "donate-footer"
-weight = 4
+weight = 8
+
+[[footer]]
+name = "Contact"
+url = "/contact.html"
+identifier = "contact-footer"
+weight = 10

--- a/content/contact.md
+++ b/content/contact.md
@@ -1,0 +1,28 @@
+---
+title: 'Contact Us'
+url: '/contact.html'
+---
+
+We'd love to hear from you! Here are the best ways to reach The Perl & Raku Foundation:
+
+## Email
+
+For general inquiries:
+
+[hello@perlfoundation.org](mailto:hello@perlfoundation.org)
+
+For sponsorship inquiries:
+
+[olaf@perlfoundation.org](mailto:olaf@perlfoundation.org)
+
+## Join Our Community on Slack
+
+Connect with the TPRF team and community members in real-time:
+
+[Join the TPRF Slack workspace](https://join.slack.com/t/perlfoundation/shared_invite/zt-3ocbigsn5-Cj7aslwG5gtbj8PDrBbeOA)
+
+Get help, share your projects, and participate in discussions about the future of Perl and Raku.
+
+## More Ways to Get Involved
+
+Looking for other ways to connect with the Perl and Raku community? Check out our [Get Involved](/get-involved.html) page for local user groups, events, and more.


### PR DESCRIPTION
## Summary
- Created a dedicated contact page with email addresses (general and sponsorship) and Slack link
- Expanded footer navigation from 2 to 5 links: News, Events, Get Involved, Donate, Contact
- Provides clearer contact information with separate emails for general (hello@perlfoundation.org) and sponsorship inquiries (olaf@perlfoundation.org)

## Changes
- Added `/contact.html` page listing all ways to reach TPRF
- Updated footer menu in config with more useful links
- Organized footer links in logical order: News → Events → Get Involved → Donate → Contact

## Test plan
- [ ] Verify contact page displays correctly at `/contact.html`
- [ ] Verify footer has 5 links in correct order
- [ ] Verify email addresses are clickable
- [ ] Verify Slack link opens in new tab
- [ ] Verify all footer links work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)